### PR TITLE
Optional preconverted strides for linearoffset

### DIFF
--- a/Tests/TestFill.swift
+++ b/Tests/TestFill.swift
@@ -35,6 +35,24 @@ internal final class TestFill: XCTestCase {
         }
     }
 
+    internal func testFillStandalone10_100000() {
+        let logits4 = MLMultiArray.logits(count: 100_000)
+        let indexes4 = indexes(count: 10)
+
+        measure(metrics: Self.metrics, options: Self.options) {
+            logits4.fillStandalone(indexes: indexes4, value: -Float.infinity)
+        }
+    }
+
+    internal func testFillWithHelper10_100000() {
+        let logits4 = MLMultiArray.logits(count: 100_000)
+        let indexes4 = indexes(count: 10)
+
+        measure(metrics: Self.metrics, options: Self.options) {
+            logits4.fillWithHelper(indexes: indexes4, value: -Float.infinity)
+        }
+    }
+
     internal func testFill100_100() {
         let logits1 = MLMultiArray.logits(count: 100)
         let indexes1 = indexes(count: 100)
@@ -67,6 +85,24 @@ internal final class TestFill: XCTestCase {
         }
     }
 
+    internal func testFillStandalone100_100000() {
+        let logits4 = MLMultiArray.logits(count: 100_000)
+        let indexes4 = indexes(count: 100)
+
+        measure(metrics: Self.metrics, options: Self.options) {
+            logits4.fillStandalone(indexes: indexes4, value: -Float.infinity)
+        }
+    }
+
+    internal func testFillWithHelper100_100000() {
+        let logits4 = MLMultiArray.logits(count: 100_000)
+        let indexes4 = indexes(count: 100)
+
+        measure(metrics: Self.metrics, options: Self.options) {
+            logits4.fillWithHelper(indexes: indexes4, value: -Float.infinity)
+        }
+    }
+
     internal func testFillAll_100() {
         let logits1 = MLMultiArray.logits(count: 100)
         let indexes1 = indexes(count: 100)
@@ -96,6 +132,24 @@ internal final class TestFill: XCTestCase {
         let indexes4 = indexes(count: 100_000)
         measure(metrics: Self.metrics, options: Self.options) {
             logits4.fill(indexes: indexes4, with: -Float.infinity)
+        }
+    }
+
+    internal func testFillStandaloneAll_100000() {
+        let logits4 = MLMultiArray.logits(count: 100_000)
+        let indexes4 = indexes(count: 100_000)
+
+        measure(metrics: Self.metrics, options: Self.options) {
+            logits4.fillStandalone(indexes: indexes4, value: -Float.infinity)
+        }
+    }
+
+    internal func testFillWithHelperAll_100000() {
+        let logits4 = MLMultiArray.logits(count: 100_000)
+        let indexes4 = indexes(count: 100_000)
+
+        measure(metrics: Self.metrics, options: Self.options) {
+            logits4.fillWithHelper(indexes: indexes4, value: -Float.infinity)
         }
     }
 }


### PR DESCRIPTION
Tested out the concurrency option - definitely looks slower for this operation, nice find! Found a couple of other potential optimizations in the process of testing it out, but haven't verified numerical accuracy.
- `fillStandalone` doesn't use the helper function and saves an allocation
- `fillWithHelper` is a little more clean but slightly slower

Results from an M2 Pro (mac mini):
```swift
    ◷ testFillAll_100000 measured (567460.225 kI ±1.206% -- CPU Instructions Retired)
    ◷ testFillAll_100000 measured (123943.925 kC ±5.248% -- CPU Cycles)
    ◷ testFillAll_100000 measured (0.037 s ±7.000% -- CPU Time)
    ◷ testFillAll_100000 measured (0.038 s ±16.279% -- Clock Monotonic Time)
    ✔ testFillAll_100000 (39.162 seconds)
    ◷ testFillStandaloneAll_100000 measured (83950.178 kI ±0.266% -- CPU Instructions Retired)
    ◷ testFillStandaloneAll_100000 measured (17762.483 kC ±4.781% -- CPU Cycles)
    ◷ testFillStandaloneAll_100000 measured (0.005 s ±5.549% -- CPU Time)
    ◷ testFillStandaloneAll_100000 measured (0.005 s ±27.057% -- Clock Monotonic Time)
    ✔ testFillStandaloneAll_100000 (5.924 seconds)
    ◷ testFillWithHelperAll_100000 measured (98987.808 kI ±0.177% -- CPU Instructions Retired)
    ◷ testFillWithHelperAll_100000 measured (20774.328 kC ±7.088% -- CPU Cycles)
    ◷ testFillWithHelperAll_100000 measured (0.006 s ±7.816% -- CPU Time)
    ◷ testFillWithHelperAll_100000 measured (0.006 s ±9.994% -- Clock Monotonic Time)
    ✔ testFillWithHelperAll_100000 (6.850 seconds)
```

Let me know what you think of these options, and I'll merge your WhisperKit PR based on what you want to bring over.